### PR TITLE
Update runtime to 6.10

### DIFF
--- a/fix-Qt-6101.patch
+++ b/fix-Qt-6101.patch
@@ -1,0 +1,43 @@
+From 5e89eefbf68aa6cd829cf44394584dd7daac6e72 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 18 Jan 2026 02:34:59 +0300
+Subject: [PATCH] Small fixes
+
+Source: 
+
+- https://github.com/fooyin/fooyin/pull/725
+- https://github.com/fooyin/fooyin/pull/780
+
+---
+ src/plugins/vumeter/vumeterwidget.cpp | 1 +
+ src/utils/starrating.cpp              | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/plugins/vumeter/vumeterwidget.cpp b/src/plugins/vumeter/vumeterwidget.cpp
+index 786f24b..2834a3e 100644
+--- a/src/plugins/vumeter/vumeterwidget.cpp
++++ b/src/plugins/vumeter/vumeterwidget.cpp
+@@ -33,6 +33,7 @@
+ #include <QActionGroup>
+ #include <QBasicTimer>
+ #include <QContextMenuEvent>
++#include <QElapsedTimer>
+ #include <QJsonObject>
+ #include <QMenu>
+ #include <QPainter>
+diff --git a/src/utils/starrating.cpp b/src/utils/starrating.cpp
+index 1e71e18..9c96e95 100644
+--- a/src/utils/starrating.cpp
++++ b/src/utils/starrating.cpp
+@@ -104,7 +104,7 @@ void StarRating::paint(QPainter* painter, const QRect& rect, const QPalette& pal
+                                  .arg(m_maxCount)
+                                  .arg(mode == EditMode::Editable ? 1 : 0)
+                                  .arg(rect.width())
+-                                 .arg(alignment);
++                                 .arg(alignment.toInt());
+ 
+     QPixmap pixmap;
+     if(!QPixmapCache::find(cacheKey, &pixmap)) {
+--
+libgit2 1.7.2
+

--- a/org.fooyin.fooyin.yaml
+++ b/org.fooyin.fooyin.yaml
@@ -1,13 +1,8 @@
 app-id: org.fooyin.fooyin
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: fooyin
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
 finish-args:
   - --device=dri
   - --filesystem=xdg-download
@@ -32,8 +27,7 @@ cleanup:
   - /mkspecs
   - /share/aclocal
   - /share/doc/KDSingleApplication-qt6
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
+
 modules:
   - name: KDSingleApplication
     buildsystem: cmake-ninja
@@ -93,6 +87,7 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: git
         url: https://github.com/jiixyj/libebur128.git
@@ -115,3 +110,5 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: v([\d.]+)
+      - type: patch
+        path: fix-Qt-6101.patch


### PR DESCRIPTION
Also, drop the ffmpeg extension

> This is supposed to ship in Freedesktop SDK 25.08. The major change for app developers is that there is no longer any need to have something like

Source: https://bbhtt.in/posts/closing-the-chapter-on-openh264/